### PR TITLE
remove useless deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,15 @@ PROJECT = xref_runner
 
 REBAR?=rebar
 
-DEPS = lager sync eper getopt
+DEPS = getopt
 
-dep_eper = git git://github.com/massemanet/eper.git 0.90.0
-dep_lager = git git://github.com/basho/lager.git 2.1.0
-dep_sync = git git://github.com/inaka/sync.git 0.1
 dep_getopt = git https://github.com/jcomellas/getopt v0.8.2
 
 DIALYZER_DIRS := ebin/
 DIALYZER_OPTS := --verbose --statistics -Werror_handling \
                  -Wrace_conditions #-Wunmatched_returns
 
-ERLC_OPTS := +'{parse_transform, lager_transform}' +'{lager_truncation_size, 32768}'
-ERLC_OPTS += +warn_unused_vars +warn_export_all +warn_shadow_vars +warn_unused_import +warn_unused_function
+ERLC_OPTS := +warn_unused_vars +warn_export_all +warn_shadow_vars +warn_unused_import +warn_unused_function
 ERLC_OPTS += +warn_bif_clash +warn_unused_record +warn_deprecated_function +warn_obsolete_guard +strict_validation
 ERLC_OPTS += +warn_export_vars +warn_exported_vars +warn_missing_spec +warn_untyped_record +debug_info
 
@@ -22,16 +18,10 @@ include erlang.mk
 
 # To avoid eunit autocompile
 TEST_ERLC_OPTS = +debug_info +warn_export_vars +warn_shadow_vars +warn_obsolete_guard
-TEST_ERLC_OPTS += +'{parse_transform, lager_transform}'
 
 # Commont Test Config
 
 CT_OPTS += -cover test/xref_runner.coverspec -vvv
-
-SHELL_OPTS= -name ${PROJECT}@`hostname` -s sync
-
-test-shell: build-ct-suites app
-	erl -pa ebin -pa deps/*/ebin -pa test -s sync -s lager
 
 # Builds the xref_runner escript.
 

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ PROJECT = xref_runner
 REBAR?=rebar
 
 DEPS = getopt
-
 dep_getopt = git https://github.com/jcomellas/getopt v0.8.2
 
+PLT_APPS := tools
 DIALYZER_DIRS := ebin/
 DIALYZER_OPTS := --verbose --statistics -Werror_handling \
                  -Wrace_conditions #-Wunmatched_returns

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 {erl_opts,
  [
-  {parse_transform, lager_transform},
   {src_dirs, ["src"]},
   warn_unused_vars,
   warn_export_all,
@@ -21,11 +20,8 @@
 {deps_dir, "deps"}.
 {deps,
  [
-  {lager,  "2.*", {git, "git://github.com/basho/lager.git",     "2.1.0"}},
-  {eper,   "0.*", {git, "git://github.com/massemanet/eper.git", "0.90.0"}},
-  {sync,   "0.*", {git, "git://github.com/inaka/sync.git",      "0.1"}},
   {getopt, "0.*", {git, "https://github.com/jcomellas/getopt",  "v0.8.2"}}
  ]
 }.
 {escript_name, "xrefr"}.
-{escript_incl_apps, [lager, eper, sync, getopt]}.
+{escript_incl_apps, [getopt]}.

--- a/src/xref_runner.app.src
+++ b/src/xref_runner.app.src
@@ -6,6 +6,7 @@
    {applications,
     [ kernel
     , stdlib
+    , tools
     , erl_interface
     ]},
    {modules, []},

--- a/src/xref_runner.app.src
+++ b/src/xref_runner.app.src
@@ -7,7 +7,6 @@
     [ kernel
     , stdlib
     , erl_interface
-    , lager
     ]},
    {modules, []},
    {registered, []}

--- a/test/xref_runner.coverspec
+++ b/test/xref_runner.coverspec
@@ -1,7 +1,7 @@
 %% Specific modules to include in cover.
 {
  incl_mods,
- [
-  xref_runner
+ [ xref_runner
+ , xrefr
  ]
 }.


### PR DESCRIPTION
Remove `lager`, `eper` and `sync` from the dependency list.
Of course, make sure they're not used before removing them.
