### PR TITLE
If no filename, don't print :0

### DIFF
--- a/src/xrefr.erl
+++ b/src/xrefr.erl
@@ -63,10 +63,13 @@ generate_comment(XrefWarning) ->
    , check    := Check
    } = XrefWarning,
   Target = maps:get(target, XrefWarning, undefined),
-  [ Filename
-  , ":", integer_to_list(Line)
-  , " ", generate_comment_text(Check, Source, Target)
-  ].
+  Position =
+    case {Filename, Line} of
+      {"", _} -> "";
+      {Filename, 0} -> [Filename, " "];
+      {Filename, Line} -> [Filename, ":", integer_to_list(Line), " "]
+    end,
+  [Position, generate_comment_text(Check, Source, Target)].
 
 generate_comment_text(Check, {SM, SF, SA}, TMFA) ->
   SMFA = io_lib:format("`~p:~p/~p`", [SM, SF, SA]),


### PR DESCRIPTION
Running xrefr we get results like…

```
:0 `x:y/1` is not defined as a function
```

They should look like…

```
`x:y/1` is not defined as a function
```
