### PR TITLE
Remove `exports_not_used` from the default list of checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 
-## [0.1.2](https://github.com/inaka/xref_runner/tree/0.1.2) (2015-03-17)
+## [0.2.0](https://github.com/inaka/xref_runner/tree/0.2.0) (2015-03-18)
 
-[Full Changelog](https://github.com/inaka/xref_runner/compare/0.1.1...HEAD)
+[Full Changelog](https://github.com/inaka/xref_runner/compare/0.1.1...0.2.0)
 
 **Closed issues:**
 
@@ -13,6 +13,10 @@
 - escriptize [\#2](https://github.com/inaka/xref_runner/issues/2)
 
 **Merged pull requests:**
+
+- If no filename, don't print :0 [\#22](https://github.com/inaka/xref_runner/pull/22) ([elbrujohalcon](https://github.com/elbrujohalcon))
+
+- Version Bump to 0.2.0 [\#21](https://github.com/inaka/xref_runner/pull/21) ([elbrujohalcon](https://github.com/elbrujohalcon))
 
 - remove useless deps [\#20](https://github.com/inaka/xref_runner/pull/20) ([elbrujohalcon](https://github.com/elbrujohalcon))
 

--- a/src/xref_runner.app.src
+++ b/src/xref_runner.app.src
@@ -2,7 +2,7 @@
   application, xref_runner,
   [
    {description, "Xref Runner"},
-   {vsn, "0.2.0"},
+   {vsn, "0.2.1"},
    {applications,
     [ kernel
     , stdlib

--- a/src/xref_runner.erl
+++ b/src/xref_runner.erl
@@ -52,13 +52,13 @@ check(Path) ->
     case file:consult(Path) of
       {ok, [FullConfig]} ->
         case proplists:get_value(xref, FullConfig) of
-          undefined -> {all_checks(), #{}};
+          undefined -> {default_checks(), #{}};
           XrefConfig ->
-            { proplists:get_value(checks, XrefConfig, all_checks())
+            { proplists:get_value(checks, XrefConfig, default_checks())
             , proplists:get_value(config, XrefConfig, #{})
             }
         end;
-      {error, enoent} -> {all_checks(), #{}}
+      {error, enoent} -> {default_checks(), #{}}
     end,
   lists:append([check(Check, Config) || Check <- Checks]).
 
@@ -94,13 +94,10 @@ check(Check, Config) ->
 %% Internal functions
 %% ===================================================================
 
-all_checks() ->
+default_checks() ->
   [ undefined_function_calls
-  , undefined_functions
   , locals_not_used
-  , exports_not_used
   , deprecated_function_calls
-  , deprecated_functions
   ].
 
 ebin() ->

--- a/test/xref_runner_SUITE.erl
+++ b/test/xref_runner_SUITE.erl
@@ -285,13 +285,13 @@ check_with_no_config_file(_Config) ->
 
     ct:comment("Run the checks in the right folder, without ebin"),
     ok = file:del_dir("ebin"),
-    Results = xref_runner:check(), %% All the warnings from the other tests
+    Results = xref_runner:check(), %% All the warnings from the default tests
     [_|_] = [1 || #{check := undefined_function_calls} <- Results],
-    [_|_] = [1 || #{check := undefined_functions} <- Results],
+    [] = [1 || #{check := undefined_functions} <- Results],
     [_|_] = [1 || #{check := locals_not_used} <- Results],
-    [_|_] = [1 || #{check := exports_not_used} <- Results],
+    [] = [1 || #{check := exports_not_used} <- Results],
     [_|_] = [1 || #{check := deprecated_function_calls} <- Results],
-    [_|_] = [1 || #{check := deprecated_functions} <- Results],
+    [] = [1 || #{check := deprecated_functions} <- Results],
 
     {comment, ""}
   after
@@ -327,16 +327,16 @@ check_with_config_file(_Config) ->
     ok = WriteConfig([{xref, []}]),
     [] = xref_runner:check(),
 
-    ct:comment("With the proper dir, but no checks, runs all checks"),
+    ct:comment("With the proper dir, but no checks, runs default checks"),
     Path = filename:dirname(code:which(ignore_xref)),
     ok = WriteConfig([{xref, [{config, #{dirs => [Path]}}]}]),
     AllResults = xref_runner:check(),
     [_|_] = [1 || #{check := undefined_function_calls} <- AllResults],
-    [_|_] = [1 || #{check := undefined_functions} <- AllResults],
+    [] = [1 || #{check := undefined_functions} <- AllResults],
     [_|_] = [1 || #{check := locals_not_used} <- AllResults],
-    [_|_] = [1 || #{check := exports_not_used} <- AllResults],
+    [] = [1 || #{check := exports_not_used} <- AllResults],
     [_|_] = [1 || #{check := deprecated_function_calls} <- AllResults],
-    [_|_] = [1 || #{check := deprecated_functions} <- AllResults],
+    [] = [1 || #{check := deprecated_functions} <- AllResults],
 
     ct:comment("With the proper dir, with checks, runs only those checks"),
     Path = filename:dirname(code:which(ignore_xref)),
@@ -437,16 +437,16 @@ check_as_script(_Config) ->
     ok = WriteConfig([{xref, []}]),
     [] = xrefr:main([]),
 
-    ct:comment("With the proper dir, but no checks, runs all checks"),
+    ct:comment("With the proper dir, but no checks, runs default checks"),
     Path = filename:dirname(code:which(ignore_xref)),
     ok = WriteConfig([{xref, [{config, #{dirs => [Path]}}]}]),
     AllResults = xrefr:main([]),
     [_|_] = [1 || #{check := undefined_function_calls} <- AllResults],
-    [_|_] = [1 || #{check := undefined_functions} <- AllResults],
+    [] = [1 || #{check := undefined_functions} <- AllResults],
     [_|_] = [1 || #{check := locals_not_used} <- AllResults],
-    [_|_] = [1 || #{check := exports_not_used} <- AllResults],
+    [] = [1 || #{check := exports_not_used} <- AllResults],
     [_|_] = [1 || #{check := deprecated_function_calls} <- AllResults],
-    [_|_] = [1 || #{check := deprecated_functions} <- AllResults],
+    [] = [1 || #{check := deprecated_functions} <- AllResults],
 
     ct:comment("With the proper dir, with checks, runs only those checks"),
     Path = filename:dirname(code:which(ignore_xref)),
@@ -454,17 +454,20 @@ check_as_script(_Config) ->
       WriteConfig(
         [ { xref
           , [ {config, #{dirs => [Path]}}
-            , {checks, [locals_not_used, exports_not_used]}
+            , {checks, [ undefined_functions
+                       , exports_not_used
+                       , deprecated_functions
+                       ]}
             ]
           }
         ] ),
     SomeResults1 = xrefr:main([]),
     [] = [1 || #{check := undefined_function_calls} <- SomeResults1],
-    [] = [1 || #{check := undefined_functions} <- SomeResults1],
-    [_|_] = [1 || #{check := locals_not_used} <- SomeResults1],
+    [_|_] = [1 || #{check := undefined_functions} <- SomeResults1],
+    [] = [1 || #{check := locals_not_used} <- SomeResults1],
     [_|_] = [1 || #{check := exports_not_used} <- SomeResults1],
     [] = [1 || #{check := deprecated_function_calls} <- SomeResults1],
-    [] = [1 || #{check := deprecated_functions} <- SomeResults1],
+    [_|_] = [1 || #{check := deprecated_functions} <- SomeResults1],
 
     ct:comment("With the proper dir, with checks == [], runs no check"),
     Path = filename:dirname(code:which(ignore_xref)),


### PR DESCRIPTION
For libraries it's misleading and most of the open-source erlang projects are libraries.
