### PR TITLE
xref_runner:find_function_source(): Convert annotation to line number

### DIFF
--- a/src/xref_runner.erl
+++ b/src/xref_runner.erl
@@ -227,7 +227,7 @@ find_function_source(M, F, A, Bin) ->
              element(4, E) == A],
 
   case Fn of
-    [{function, Line, F, _, _}] -> {Source, Line};
+    [{function, Line, F, _, _}] -> {Source, erl_anno:line(Line)};
     %% do not crash if functions are exported, even though they
     %% are not in the source.
     %% parameterized modules add new/1 and instance/1 for example.


### PR DESCRIPTION
In the specification of `af_function_decl()`, the line number is not available directly: it's an opaque type named `erl_anno:anno()`. To get the actual line number, we must call the `erl_anno:line/1` function.

This fixes several errors reported by Dialyzer in the `xref_runner_SUITE.erl` testsuite.

References #61.