### PR TITLE
Add Support to ignore a whole module via -ignore_xref()

### DIFF
--- a/test/examples/ignore_xref2.erl
+++ b/test/examples/ignore_xref2.erl
@@ -1,0 +1,21 @@
+-module(ignore_xref2).
+
+-ignore_xref(ignore_xref2).
+-deprecated({internal, '_'}).
+
+-export([bad/0, bad/1, good/0, internal/0, ignored/0]).
+
+bad() ->
+  deprecated_functions:deprecated().
+
+bad(1) ->
+  _ = ignore_xref:internal(),
+  deprecated_functions:deprecated(1).
+
+good() ->
+  deprecated_functions:not_deprecated().
+
+internal() -> {this, is, deprecated}.
+
+ignored() ->
+  ignore_xref:ignored().

--- a/test/xref_runner_SUITE.erl
+++ b/test/xref_runner_SUITE.erl
@@ -11,6 +11,7 @@
         , deprecated_function_calls/1
         , deprecated_functions/1
         , ignore_xref/1
+        , ignore_xref2/1
         , check_with_config_file/1
         , check_with_no_config_file/1
         , check_as_script/1
@@ -316,6 +317,19 @@ ignore_xref(_Config) ->
   ct:comment("It contains no other warnings"),
   [] = Warnings -- [W1, W2],
 
+
+  {comment, ""}.
+
+-spec ignore_xref2(config()) -> {comment, string()}.
+ignore_xref2(_Config) ->
+  Path = get_path("ignore_xref"),
+  Config = #{ dirs => [Path] },
+  AllWarnings = xref_runner:check(deprecated_function_calls, Config),
+   Warnings =
+    [W || W = #{filename := F} <- AllWarnings
+        , filename:basename(F) == "ignore_xref2.erl"],
+  Config = #{ dirs => [Path] },
+  [] = Warnings,
   {comment, ""}.
 
 -spec check_with_no_config_file(config()) -> {comment, string()}.


### PR DESCRIPTION
This PR is for supporting module() in xref ignores  via -xref_ignore() module attribute.

The current specification (prior to this PR) for xref ignores is :
```erlang
[{module(), function(), arity()} | {module(), function()}].
```

However, it is often desirable to ignore an entire module for varying reasons. This patch updates the specification to:
```erlang
[module() | {module(), function(), arity()} | {module(), function()}]
```

Closes #70 